### PR TITLE
models.draw - fix issue when model has no indices property

### DIFF
--- a/tdl/models.js
+++ b/tdl/models.js
@@ -163,7 +163,9 @@ tdl.models.Model.prototype.drawPrep = function() {
  */
 tdl.models.Model.prototype.draw = function() {
   var buffers = this.buffers;
-  var totalComponents = buffers.indices.totalComponents();
+  // if no indices buffer then assume drawFunc is drawArrays and thus
+  // totalComponents is the number of vertices (not indices).
+  var totalComponents = buffers.indices? buffers.indices.totalComponents(): buffers.position.numElements();
   var startOffset = 0;
   for (var ii = 0; ii < arguments.length; ++ii) {
     var arg = arguments[ii];


### PR DESCRIPTION
Fixed issue in models.draw where totalComponents value was assumed to be the number of indices components even when model did not have an indices property. This results in not being able to use the drawArrays draw function.

To fix, we assume that if a model has no indices property then totalComponents should be the number of vertices in the model. 

With this change I can simply make my model have arrays like:
{ position: positions} 
